### PR TITLE
fix:No.13_カテゴリ未登録の商品も一覧に表示されるよう修正

### DIFF
--- a/src/main/java/com/example/model/Product.java
+++ b/src/main/java/com/example/model/Product.java
@@ -38,7 +38,7 @@ public class Product extends TimeEntity implements Serializable {
 	@Column(name = "name", nullable = false)
 	private String name;
 
-	@Column(name = "code", nullable = false)
+	@Column(name = "code", nullable = true)
 	private String code;
 
 	@Column(name = "weight", nullable = false)

--- a/src/main/java/com/example/service/ProductService.java
+++ b/src/main/java/com/example/service/ProductService.java
@@ -15,6 +15,7 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
 
 import com.example.entity.ProductWithCategoryName;
@@ -62,8 +63,9 @@ public class ProductService {
 		final CriteriaQuery<ProductWithCategoryName> query = builder.createQuery(ProductWithCategoryName.class);
 		final Root<Product> root = query.from(Product.class);
 
-		Join<Product, CategoryProduct> categoryProductJoin = root.joinList("categoryProducts");
-		Join<CategoryProduct, Category> categoryJoin = categoryProductJoin.join("category");
+		// LEFT JOIN でカテゴリー情報を結合
+		Join<Product, CategoryProduct> categoryProductJoin = root.joinList("categoryProducts", JoinType.LEFT);
+		Join<CategoryProduct, Category> categoryJoin = categoryProductJoin.join("category", JoinType.LEFT);
 
 		query.multiselect(
 				root.get("id"),
@@ -125,7 +127,7 @@ public class ProductService {
 
 	/**
 	 * ProductFormの内容を元に商品情報を保存する
-	 * 
+	 *
 	 * @param entity
 	 * @return
 	 */


### PR DESCRIPTION
**概要**
　　・カテゴリが未設定の商品が一覧に表示されないため、カテゴリ未設定の場合でも一覧に表示されるよう修正

**修正方針**
　　・テーブルの情報取得時に内部結合になっており、カテゴリーの紐づけの無い商品が反映されていない状態のため、
　　　外部結合にしてカテゴリーの紐づけの無い商品も取得できるようにする

**変更点**
　ProductService.java
　　・テーブルの結合方法を内部結合→外部結合(下記)へ変更
```
Join<Product, CategoryProduct> categoryProductJoin = root.joinList("categoryProducts", JoinType.LEFT);
Join<CategoryProduct, Category> categoryJoin = categoryProductJoin.join("category", JoinType.LEFT);
```