### PR TITLE
fix:No.14_商品検索時にAND検索になるように修正

### DIFF
--- a/src/main/java/com/example/service/ProductService.java
+++ b/src/main/java/com/example/service/ProductService.java
@@ -88,8 +88,17 @@ public class ProductService {
 		}
 
 		if (form.getCategories() != null && form.getCategories().size() > 0) {
-			// categories で完全一致検索
-			query.where(categoryJoin.get("id").in(form.getCategories()));
+			List<Long> productIdList = entityManager
+					.createQuery(
+							"select cp.product.id from CategoryProduct cp where cp.category.id in :categoryIds group by cp.product.id having count(cp.product.id) = :categoryCount",
+							Long.class)
+					.setParameter("categoryIds", form.getCategories())
+					.setParameter("categoryCount", (long)form.getCategories().size())
+					.getResultList();
+
+			query.where(root.get("id").in(productIdList));
+
+			query.where(builder.in(root.get("id")).value(productIdList));
 		}
 
 		// weight で範囲検索(上限/下限片方の指定だけでも検索可能)


### PR DESCRIPTION
**概要**
　・複数カテゴリでの検索時にOR検索になっている。
　　検索条件でカテゴリを複数選択して検索した場合、どちらにも紐づいている商品を検索できるよう修正。

**修正方針**
　・フォームに入力されたカテゴリーの数と複数のカテゴリーを持つ商品が同数になる場合、
　　その商品情報を取得するように記述を修正

**変更点**

- ProductService.java
・クエリの作成:`CategoryProduct`テーブルから、特定の商品IDを取得するクエリを作成。
　　特定のカテゴリIDがフォームから取得したカテゴリIDリスト (categoryIds) に含まれ、
　　商品IDでグループ化した結果の中で、**商品IDの出現回数＝フォームで選択されたカテゴリー数**の時、
　　テーブルから該当する商品情報を取得する。
　　　　　　
・クエリのパラメータ設定:クエリのパラメータとして`categoryIds`と`categoryCount`を下記内容で設定。
　　`categoryIds`→フォームから取得したカテゴリIDリスト
　　`categoryCount`→フォームから取得したカテゴリIDの数

　　・クエリの実行:クエリ実行時、上記の条件を満たす商品IDが`List<Long> productIdList`に格納される。

　　・クエリの結果をフィルタリング:取得した商品IDリストを基にさらにフィルタリングし、
　　画面表示に必要な商品情報を取得。query.where()を使用して、`root.get("id").in(productIdList) `と 　
　　`builder.in(root.get("id")).value(productIdList) `の2つの条件を追加し、取得した商品IDリストに一致する商品を取得。

　　SQLでクエリ文を書いた場合は下記
```
SELECT cp.product.id
FROM CategoryProduct cp
WHERE cp.category.id IN (:categoryIds)
GROUP BY cp.product.id
HAVING COUNT(cp.product.id) = :categoryCount;
```