### PR TITLE
fix:No.16_取引金額登録画面でメモが1001字以上入力できる不具合を修正

### DIFF
--- a/src/main/java/com/example/constants/Validate.java
+++ b/src/main/java/com/example/constants/Validate.java
@@ -6,5 +6,8 @@ package com.example.constants;
 public final class Validate {
 	public static final Integer PRICE_UPPER = 1000000000;
 	public static final Integer EXPENSE_PRICE_UPPER = 500000000;
-	public static final Integer TEXT_LENGTH = 2000;
+	// 取引金額 新規登録/編集 > メモ 制限文字数：1000文字まで
+	public static final Integer MEMO_TEXT_LENGTH = 1000;
+	// apps 新規登録/編集 > Description 制限文字数：2000文字まで
+	public static final Integer DESCRIPTION_TEXT_LENGTH = 2000;
 }

--- a/src/main/java/com/example/controller/TransactionAmountController.java
+++ b/src/main/java/com/example/controller/TransactionAmountController.java
@@ -148,12 +148,12 @@ public class TransactionAmountController {
 			if (!transactionAmountService.validate(entity)) {
 				// NG
 				redirectAttributes.addFlashAttribute("error", Message.MSG_VALIDATE_ERROR);
-				return "redirect:/companies";
+				return "redirect:/transactionAmounts/" + entity.getId() + "/edit";
 			}
 
 			tAmount = transactionAmountService.save(entity);
 			redirectAttributes.addFlashAttribute("success", Message.MSG_SUCESS_UPDATE);
-			return "redirect:/companies/" + tAmount.getCompanyId();
+			return "redirect:/transactionAmounts/" + tAmount.getCompanyId();
 		} catch (Exception e) {
 			redirectAttributes.addFlashAttribute("error", Message.MSG_ERROR);
 			e.printStackTrace();

--- a/src/main/java/com/example/service/TransactionAmountService.java
+++ b/src/main/java/com/example/service/TransactionAmountService.java
@@ -85,7 +85,7 @@ public class TransactionAmountService {
 		}
 		// メモは1000文字以下か
 		if (Objects.nonNull(entity.getMemo())) {
-			if (entity.getMemo().length() >= Validate.TEXT_LENGTH) {
+			if (entity.getMemo().length() > Validate.MEMO_TEXT_LENGTH) {
 				return false;
 			}
 		}

--- a/src/main/java/com/example/utils/CheckUtil.java
+++ b/src/main/java/com/example/utils/CheckUtil.java
@@ -12,8 +12,8 @@ public class CheckUtil {
 	 * @return boolean
 	 */
 	public static boolean checkDescriptionLength(String description) {
-		// descriptionは2000文字以下か
-		if (Objects.nonNull(description) && description.length() > Validate.TEXT_LENGTH) {
+		// descriptionは000文字以下か
+		if (Objects.nonNull(description) && description.length() > Validate.DESCRIPTION_TEXT_LENGTH) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
**概要**
　　取引金額のメモが1000文字より多く入力しても登録できる状態のため、設計に沿った入力となるように修正。

**修正方針**
　　・既存の入力バリデーションが2000文字までのものしかなかったため、
　　　説明欄用(2000文字まで入力可)の定数`DESCRIPTION_TEXT_LENGTH`と
　　　メモ用(1000文字まで入力可)‘MEMO_TEXT_LENGTH‘の定数を作成
　　・上記に伴い、該当する箇所の定数名を修正
　　・データの更新成功時、会社一覧画面に遷移していたため取引金額 詳細画面に遷移するよう修正

**変更点**

- Validate.java

　　・既存のコードに2000文字までのバリデーションが実装されていたため、
　　1000文字までのバリデーションが行えるよう新たな定数‘MEMO_TEXT_LENGTH‘を作成

-  CheckUtil.java

　　・説明欄用(2000文字まで入力可)のバリデーションの定数`DESCRIPTION_TEXT_LENGTH`へ変更

- TransactionAmountService.java　
　
・メモ用(1000文字まで入力可)のバリデーションの定数`MEMO_TEXT_LENGTH`へ変更

- TransactionAmountController.java

　　・データの更新成功時、会社一覧画面に遷移していたため取引金額 詳細画面に遷移するよう修正