### PR TITLE
fix:No.25_商品一覧画面で同一商品が複数表示されているため修正

### DIFF
--- a/src/main/java/com/example/controller/ShopProductController.java
+++ b/src/main/java/com/example/controller/ShopProductController.java
@@ -43,16 +43,7 @@ public class ShopProductController {
 	public String index(Model model, @PathVariable("shopId") Long shopId, @ModelAttribute ProductSearchForm request) {
 		List<ProductWithCategoryName> all = productService.search(shopId, request);
 		List<Category> categories = categoryService.findAll();
-		List<ProductWithCategoryName> products = new ArrayList<ProductWithCategoryName>();
-		for (ProductWithCategoryName product : all) {
-			for (ProductWithCategoryName productsCategoryName : products) {
-				if (productsCategoryName.getName().equals(product.getName())) {
-					productsCategoryName.setCategoryName(
-							productsCategoryName.getCategoryName() + " , " + product.getCategoryName());
-				}
-			}
-			products.add(product);
-		}
+
 		model.addAttribute("listProduct", all);
 		model.addAttribute("categories", categories);
 		model.addAttribute("request", request);

--- a/src/main/java/com/example/controller/ShopProductController.java
+++ b/src/main/java/com/example/controller/ShopProductController.java
@@ -1,5 +1,6 @@
 package com.example.controller;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,11 +39,30 @@ public class ShopProductController {
 	@Autowired
 	private CategoryService categoryService;
 
-
 	@GetMapping
 	public String index(Model model, @PathVariable("shopId") Long shopId, @ModelAttribute ProductSearchForm request) {
 		List<ProductWithCategoryName> all = productService.search(shopId, request);
+		// 結果の取得→forで回して、商品毎にカテゴリー配列にpushする→商品のDTOを作成する
 		List<Category> categories = categoryService.findAll();
+		List<ProductWithCategoryName> products = new ArrayList<ProductWithCategoryName>();
+		// allから重複していない商品名を取得する
+		System.out.println("all:" + all.get(0).getName());
+		System.out.println("all:" + all.get(2).getName());
+		System.out.println("all:" + all.get(1).getName());
+
+		// for文で回して、カテゴリーを取得する,商品名が重複している場合は
+		for (ProductWithCategoryName product : all) {
+			System.out.println("product:" + product);
+			// 重複している場合は、カテゴリーを追加する → 重複していない場合は、そのまま追加する
+			for (ProductWithCategoryName productsCategoryName : products) {
+				if (productsCategoryName.getName().equals(product.getName())) {
+					productsCategoryName.setCategoryName(
+							productsCategoryName.getCategoryName() + " , " + product.getCategoryName());
+					System.out.println("productsCategoryName:" + productsCategoryName);
+				}
+			}
+			products.add(product);
+		}
 		model.addAttribute("listProduct", all);
 		model.addAttribute("categories", categories);
 		model.addAttribute("request", request);
@@ -73,7 +93,8 @@ public class ShopProductController {
 	}
 
 	@PostMapping
-	public String create(Model model, @PathVariable("shopId") Long shopId, @Validated @ModelAttribute ProductForm productForm,
+	public String create(Model model, @PathVariable("shopId") Long shopId,
+			@Validated @ModelAttribute ProductForm productForm,
 			BindingResult result, RedirectAttributes redirectAttributes) {
 		// バリデーションチェック
 		if (result.hasErrors()) {
@@ -113,8 +134,9 @@ public class ShopProductController {
 	}
 
 	@PutMapping
-	public String update(Model model, @PathVariable("shopId") Long shopId, @Validated @ModelAttribute ProductForm productForm,
-			BindingResult result,RedirectAttributes redirectAttributes) {
+	public String update(Model model, @PathVariable("shopId") Long shopId,
+			@Validated @ModelAttribute ProductForm productForm,
+			BindingResult result, RedirectAttributes redirectAttributes) {
 		System.out.append(Message.MSG_ERROR, 0, 0);
 		// バリデーションチェック
 		if (result.hasErrors()) {

--- a/src/main/java/com/example/controller/ShopProductController.java
+++ b/src/main/java/com/example/controller/ShopProductController.java
@@ -42,23 +42,13 @@ public class ShopProductController {
 	@GetMapping
 	public String index(Model model, @PathVariable("shopId") Long shopId, @ModelAttribute ProductSearchForm request) {
 		List<ProductWithCategoryName> all = productService.search(shopId, request);
-		// 結果の取得→forで回して、商品毎にカテゴリー配列にpushする→商品のDTOを作成する
 		List<Category> categories = categoryService.findAll();
 		List<ProductWithCategoryName> products = new ArrayList<ProductWithCategoryName>();
-		// allから重複していない商品名を取得する
-		System.out.println("all:" + all.get(0).getName());
-		System.out.println("all:" + all.get(2).getName());
-		System.out.println("all:" + all.get(1).getName());
-
-		// for文で回して、カテゴリーを取得する,商品名が重複している場合は
 		for (ProductWithCategoryName product : all) {
-			System.out.println("product:" + product);
-			// 重複している場合は、カテゴリーを追加する → 重複していない場合は、そのまま追加する
 			for (ProductWithCategoryName productsCategoryName : products) {
 				if (productsCategoryName.getName().equals(product.getName())) {
 					productsCategoryName.setCategoryName(
 							productsCategoryName.getCategoryName() + " , " + product.getCategoryName());
-					System.out.println("productsCategoryName:" + productsCategoryName);
 				}
 			}
 			products.add(product);

--- a/src/main/java/com/example/entity/ProductWithCategoryName.java
+++ b/src/main/java/com/example/entity/ProductWithCategoryName.java
@@ -1,7 +1,5 @@
 package com.example.entity;
 
-import java.util.List;
-
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/com/example/entity/ProductWithCategoryName.java
+++ b/src/main/java/com/example/entity/ProductWithCategoryName.java
@@ -1,5 +1,7 @@
 package com.example.entity;
 
+import java.util.List;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,7 +25,8 @@ public class ProductWithCategoryName {
 
 	private String categoryName;
 
-	public ProductWithCategoryName(Long id, String code, String name, Integer weight, Integer height, Integer price, String categoryName) {
+	public ProductWithCategoryName(Long id, String code, String name, Integer weight, Integer height, Integer price,
+			String categoryName) {
 		this.setId(id);
 		this.setCode(code);
 		this.setName(name);

--- a/src/main/java/com/example/service/ProductService.java
+++ b/src/main/java/com/example/service/ProductService.java
@@ -74,7 +74,16 @@ public class ProductService {
 				root.get("weight"),
 				root.get("height"),
 				root.get("price"),
-				categoryJoin.get("name").alias("categoryName")).where(builder.equal(root.get("shopId"), shopId));
+				builder.function("GROUP_CONCAT", String.class, categoryJoin.get("name")).alias("categoryName")).where(
+						builder.equal(root.get("shopId"), shopId),
+						builder.like(root.get("name"), "%" + form.getName() + "%"))
+				.groupBy(
+						root.get("id"),
+						root.get("code"),
+						root.get("name"),
+						root.get("weight"),
+						root.get("height"),
+						root.get("price"));
 
 		// formの値を元に検索条件を設定する
 		if (!StringUtils.isEmpty(form.getName())) {


### PR DESCRIPTION
**概要**
　商品一覧に同じ商品が重複して表示されている

**修正方針**
　・データのセレクト時にカテゴリー名以外のデータを一つにまとめてControllerへ渡す(groupby使用)

**変更点**
　・ProductService.java
　　→クエリにGROUP BY句を使用して、categoryName以外のデータをまとめるように記述を追加