### PR TITLE
fix:No.27_取引金額に0を入力した際に正常に入力されない不具合を修正

### DIFF
--- a/src/main/java/com/example/service/TransactionAmountService.java
+++ b/src/main/java/com/example/service/TransactionAmountService.java
@@ -72,7 +72,7 @@ public class TransactionAmountService {
 			return false;
 		}
 		// 金額が0以上か
-		if (entity.getPrice() <= 0) {
+		if (entity.getPrice() < 0) {
 			return false;
 		}
 		// 金額が10億円以下か


### PR DESCRIPTION
**概要**
　金額入力のバリデーションが0円以下で引っかかるようになっているため、0円入力時も登録が行えるように修正

**修正方針**
　0円入力時にバリデーションにひっかからないように演算子を修正

**変更点**
　TransactionAmountService.java
　　if (entity.getPrice() < 0) {
			return false;
	}