### PR TITLE
fix:No.11_カテゴリーと商品の紐づけに関する内容を修正

### DIFF
--- a/src/main/java/com/example/controller/CategoryController.java
+++ b/src/main/java/com/example/controller/CategoryController.java
@@ -1,5 +1,6 @@
 package com.example.controller;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,6 +22,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.constants.Message;
 import com.example.model.Category;
+import com.example.model.CategoryProduct;
 import com.example.service.CategoryService;
 import com.example.model.Product;
 import com.example.service.ProductService;
@@ -114,6 +116,14 @@ public class CategoryController {
 			Optional<Category> category = categoryService.findOne(id);
 			model.addAttribute("category", category.get());
 			model.addAttribute("products", listProduct);
+
+			// カテゴリーIDに紐付いている商品IDをList格納
+			List<Long> data = new ArrayList<>();
+			for (CategoryProduct categoryProduct : category.get().getCategoryProducts()) {
+				Long productId = categoryProduct.getProductId();
+				data.add(productId);
+			}
+			model.addAttribute("data", data);
 
 			if (q != null && (q.equals("create") || q.equals("update"))) {
 				model.addAttribute("action", true);

--- a/src/main/java/com/example/model/Category.java
+++ b/src/main/java/com/example/model/Category.java
@@ -43,4 +43,6 @@ public class Category extends TimeEntity implements Serializable {
 
 	@OneToMany(mappedBy = "category", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private List<CategoryProduct> categoryProducts;
+
+	// protectedとのリレーション
 }

--- a/src/main/resources/static/js/category/category-product.js
+++ b/src/main/resources/static/js/category/category-product.js
@@ -39,8 +39,9 @@ $(document).ready(function () {
       // JSON形式に変換
       let postData = {
       productIds: checkedIds,
-      };
-      let postDataJson = JSON.stringify(postData);
+    };
+    // postDateをJSONに変換
+    postData = JSON.stringify(postData);
 
     $.ajax({
       url: "/api/categories/" + categoryId + "/updateCategoryProduct",

--- a/src/main/resources/static/js/category/category-product.js
+++ b/src/main/resources/static/js/category/category-product.js
@@ -1,15 +1,17 @@
 $(document).ready(function () {
   let categoryId = document.getElementById("categoryId").getAttribute("val");
-  let action = document.getElementById("action").getAttribute("val");
+  let action = document.getElementById("action").getAttribute("value");
+
 
   $.ajax({
-    url: "/api/category/" + categoryId,
+    url: "/categories/" + categoryId + "/productRelation",
     type: "GET",
     dataType: "json",
     contentType: "application/json",
   })
     .done(function (data) {
       var categoryProducts = data;
+      console.log("APIコールが成功");
       // チェックボックスにチェックを入れる処理
       categoryProducts.forEach(function (categoryProduct) {
         $("#checkbox-" + categoryProduct.productId).prop("checked", true);
@@ -20,49 +22,56 @@ $(document).ready(function () {
       console.log("APIコールが失敗しました。");
     });
 
-  $("#update-button").click(function () {
+    $("#update-button").click(function () {
     var checkedIds = $(".form-check-input:checked")
       .map(function () {
         return this.value;
       })
       .get();
 
-    // 作成更新時に紐付けが存在しない場合はスキップ
-    if (action == "true") {
-      if (!validation(checkedIds)) {
-        return false;
+      // 作成更新時に紐付けが存在しない場合はスキップ
+      if (action == "true") {
+        if (!validation(checkedIds)) {
+          return false;
+        }
       }
-    }
 
-    let postData = {
+      // JSON形式に変換
+      let postData = {
       productIds: checkedIds,
-    };
+      };
+      let postDataJson = JSON.stringify(postData);
 
     $.ajax({
       url: "/api/categories/" + categoryId + "/updateCategoryProduct",
       type: "POST",
-      dataType: "text",
+      dataType: "json",
       contentType: "application/json",
-      data: postData,
-    }).done(function (data) {
-      $("#success-message").text(data).show().fadeOut(3000);
-    }.fail(function () {
-      // APIコールが失敗した場合の処理
-      validation(checkedIds);
+      data: postDataJson,
     })
-    );
-  });
+      .done(function (data) {
+        $("#success-message")
+          .text(data)
+          .show()
+          .fadeOut(3000);
+        })
+      .fail(function () {
+        // APIコールが失敗した場合の処理
+        validation(checkedIds);
+        console.log("APIコールが失敗しました。");
+      });
+    });
 
-  validation = function (checkedIds) {
-    if (checkedIds.length == 0) {
-      $("#error-message")
+    validation = function (checkedIds) {
+      if (checkedIds.length == 0) {
+        $("#error-message")
         .text(
           "商品を選択して更新か、不要な場合はカテゴリー一覧を選択して下さい。"
-        )
-        .show()
-        .fadeOut(3000);
-      return false;
-    }
+          )
+          .show()
+          .fadeOut(3000);
+          return false;
+        }
     return true;
   };
 });

--- a/src/main/resources/static/js/category/category-product.js
+++ b/src/main/resources/static/js/category/category-product.js
@@ -10,12 +10,6 @@ $(document).ready(function () {
     contentType: "application/json",
   })
     .done(function (data) {
-      var categoryProducts = data;
-      console.log("APIコールが成功");
-      // チェックボックスにチェックを入れる処理
-      categoryProducts.forEach(function (categoryProduct) {
-        $("#checkbox-" + categoryProduct.productId).prop("checked", true);
-      });
     })
     .fail(function () {
       // APIコールが失敗した場合の処理
@@ -48,20 +42,16 @@ $(document).ready(function () {
       type: "POST",
       dataType: "json",
       contentType: "application/json",
-      data: postDataJson,
+      data: postData,
+    }).done (function (responseData) {
+      $("#success-message").text(responseData).show().fadeOut(3000);
+    }.fail (function () {
+      // APIコールが失敗した場合の処理
+      validation(checkedIds);
+      console.log("APIコールが失敗しました。");
     })
-      .done(function (data) {
-        $("#success-message")
-          .text(data)
-          .show()
-          .fadeOut(3000);
-        })
-      .fail(function () {
-        // APIコールが失敗した場合の処理
-        validation(checkedIds);
-        console.log("APIコールが失敗しました。");
-      });
-    });
+    );
+  });
 
     validation = function (checkedIds) {
       if (checkedIds.length == 0) {

--- a/src/main/resources/templates/category/productRelation.html
+++ b/src/main/resources/templates/category/productRelation.html
@@ -48,6 +48,7 @@
     <hr />
     <div class="form-group">
       <label for="products">紐付商品一覧: </label>
+      <br>
       <div class="d-inline" th:each="product : ${products}">
         <input
           class="form-check-input"
@@ -60,6 +61,7 @@
           th:for="'checkbox-' + ${product.id}"
           th:text="${product.name}"
         ></label>
+        <br>
       </div>
     </div>
     <button id="update-button" class="btn btn-primary">紐付更新</button>

--- a/src/main/resources/templates/category/productRelation.html
+++ b/src/main/resources/templates/category/productRelation.html
@@ -55,7 +55,7 @@
           type="checkbox"
           th:id="'checkbox-' + ${product.id}"
           th:value="${product.id}"
-        />
+          th:checked="${data.contains(product.id) ? true : false}" />
         <label
           class="form-check-label"
           th:for="'checkbox-' + ${product.id}"


### PR DESCRIPTION
**概要**
　・ カテゴリーを開いた際に紐付けされている商品のチェックボックスが入っていない。
　・ 選択した商品を紐付け更新しようとしても更新が出来ない。
　・API通信が失敗した時はエラー表示してほしい。

**修正方針**
　・カテゴリーIDに紐づく商品IDのチェックボックスにチェックが入るように修正
　・Ajaxで送るデータをJSONに変換して送るように修正
　・Ajax(POST)の失敗時にconsole.log("APIコールが失敗しました。");を追加

**変更点**
　・CategoryController.java
　　　ブラウザのチェックを付けるため、カテゴリーIDに紐付いている商品IDをList格納するfor文を記述
　・productRelation.html
　　　<input>タグを作成し、th:checked="${data.contains(product.id) ? true : false}" を記述。
　　　CategoryControllerから渡ってきたListを基に当該箇所にチェックを付ける。
　・CategoryService.java
　　　商品登録時につけられたチェック(checkedIds)を基にDBに登録するためのfor文を記述
　　　(ブランチの管理や操作にミスがあり、トランザクションの部分は別のタスクのものです。)