### PR TITLE
fix:No.11_カテゴリーと商品の紐づけに関する内容を修正　⇒タスクを誤認していたため再度修正

### DIFF
--- a/src/main/java/com/example/service/CategoryService.java
+++ b/src/main/java/com/example/service/CategoryService.java
@@ -4,8 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import com.example.model.Category;
 import com.example.model.CategoryProduct;
-import com.example.model.Product;
-import com.example.repository.ProductRepository;
 import com.example.repository.CategoryRepository;
 import com.example.repository.CategoryProductRepository;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,9 +21,6 @@ public class CategoryService {
 
 	@Autowired
 	private CategoryProductRepository categoryProductRepository;
-
-	@Autowired
-	private ProductRepository productRepository;
 
 	public List<Category> findAll() {
 		return categoryRepository.findAll();
@@ -68,20 +63,9 @@ public class CategoryService {
 			Category category = categoryOptional.get();
 
 			for (Long productId : productIds) {
-				Optional<Product> productOptional = productRepository.findById(productId);
-				if (productOptional.isPresent()) {
-					Product product = productOptional.get();
-
-					// 新しいCategoryProductエンティティを作成
-					CategoryProduct categoryProduct = new CategoryProduct();
-					categoryProduct.setCategory(category);
-					categoryProduct.setProduct(product);
-
-					// CategoryProductエンティティを保存
-					categoryProductRepository.save(categoryProduct);
-				}
+				CategoryProduct categoryProduct = new CategoryProduct(category.getId(), productId);
+				categoryProductRepository.save(categoryProduct);
 			}
 		}
 	}
-
 }

--- a/src/main/resources/static/js/category/category-product.js
+++ b/src/main/resources/static/js/category/category-product.js
@@ -2,67 +2,50 @@ $(document).ready(function () {
   let categoryId = document.getElementById("categoryId").getAttribute("val");
   let action = document.getElementById("action").getAttribute("value");
 
-
-  $.ajax({
-    url: "/categories/" + categoryId + "/productRelation",
-    type: "GET",
-    dataType: "json",
-    contentType: "application/json",
-  })
-    .done(function (data) {
-    })
-    .fail(function () {
-      // APIコールが失敗した場合の処理
-      console.log("APIコールが失敗しました。");
-    });
-
-    $("#update-button").click(function () {
+  $("#update-button").click(function () {
     var checkedIds = $(".form-check-input:checked")
       .map(function () {
         return this.value;
       })
       .get();
 
-      // 作成更新時に紐付けが存在しない場合はスキップ
-      if (action == "true") {
-        if (!validation(checkedIds)) {
-          return false;
-        }
+    // 作成更新時に紐付けが存在しない場合はスキップ
+    if (action == "true") {
+      if (!validation(checkedIds)) {
+        return false;
       }
+    }
 
-      // JSON形式に変換
-      let postData = {
+    // JSON形式に変換
+    let postData = {
       productIds: checkedIds,
     };
-    // postDateをJSONに変換
-    postData = JSON.stringify(postData);
 
     $.ajax({
       url: "/api/categories/" + categoryId + "/updateCategoryProduct",
       type: "POST",
-      dataType: "json",
+      dataType: "text",
       contentType: "application/json",
-      data: postData,
-    }).done (function (responseData) {
-      $("#success-message").text(responseData).show().fadeOut(3000);
-    }.fail (function () {
-      // APIコールが失敗した場合の処理
-      validation(checkedIds);
-      console.log("APIコールが失敗しました。");
+      data: JSON.stringify(postData),
     })
-    );
+    .done(function (data, textStatus, jqXHR) {
+      if (checkedIds.length === 0) {
+        $("#error-message")
+          .text("商品を選択して更新か、不要な場合はカテゴリー一覧を選択して下さい。")
+          .show()
+          .fadeOut(3500);
+      } else {
+        $("#success-message").text("更新に成功しました。").show().fadeOut(3000);
+      console.log("通信に成功しました。", "ステータスコード：" + jqXHR.status);
+      }
+    })
+    .fail(function (jqXHR, textStatus, errorThrown) {
+      $("#error-message").text("更新に失敗しました。").show().fadeOut(3000);
+      console.log("通信に失敗しました。", "ステータスコード：" + jqXHR.status);
+    });
   });
 
-    validation = function (checkedIds) {
-      if (checkedIds.length == 0) {
-        $("#error-message")
-        .text(
-          "商品を選択して更新か、不要な場合はカテゴリー一覧を選択して下さい。"
-          )
-          .show()
-          .fadeOut(3000);
-          return false;
-        }
+  function validation(checkedIds) {
     return true;
-  };
+  }
 });

--- a/src/main/resources/templates/category/productRelation.html
+++ b/src/main/resources/templates/category/productRelation.html
@@ -56,7 +56,7 @@
           type="checkbox"
           th:id="'checkbox-' + ${product.id}"
           th:value="${product.id}"
-          th:checked="${data.contains(product.id) ? true : false}" />
+          th:checked="${data.contains(product.id) ? true : false}"/>
         <label
           class="form-check-label"
           th:for="'checkbox-' + ${product.id}"


### PR DESCRIPTION
**概要**
　・ カテゴリーを開いた際に紐付けされている商品のチェックボックスが入っていない。
　・ 選択した商品を紐付け更新しようとしても更新が出来ない。
　・API通信が失敗した時はエラー表示してほしい。

**修正方針**
　・Ajax(GET)の処理でチェックボックスを反映させる処理を、サーバーからブラウザにデータ渡して反映させる
　・Ajaxで送るデータをJSONに変換して送るように修正
　・Ajax(POST)の成功時に「更新に成功しました。」のメッセージが出るように修正
　・Ajax(POST)の失敗時に「更新に失敗しました。」のメッセージが出るように修正

**変更点**

- productRelation.html

　　　・<input>タグを作成し下記のコードを追記。
```
　　　　　<input　class="form-check-input"　type="checkbox"　th:id="'checkbox-' + ${product.id}"
　　　　　th:value="${product.id}"　th:checked="${data.contains(product.id) ? true : false}"/>
```

- CategoryService.java

　　　・余計な処理を記述していたため、手を加える前のコードに戻す

- category-product.js

　　　・AjaxのGET通信の記述を削除(ajaxではなく、そのままHTMLにデータを渡すようにしたため)
　　　・AjaxのPOST通信で送信するデータ(postData)をjson文字列に変換　_`data: postData ⇒ data: JSON.stringify(postData)`_
　　　・AjaxのPOST通信成功時、「更新に成功しました。」とメッセージが出るように下記を記述。
　　　　また、チェックを付けずに登録した際にバリデーションチェックとメッセージ表示のメソッドを
　　　　AjaxのPOST通信成功時の処理に移動
``` 
　　　 .done(function (data, textStatus, jqXHR) {
      　　　if (checkedIds.length === 0) {
        　　　　$("#error-message")
          　　　　.text("商品を選択して更新か、不要な場合はカテゴリー一覧を選択して下さい。").show().fadeOut(3500);
      　　　} else {
       　　　　 $("#success-message").text("更新に成功しました。").show().fadeOut(3000);
      　　　　　console.log("通信に成功しました。", "ステータスコード：" + jqXHR.status);
```
　　　・AjaxのPOST通信失敗時、「更新に失敗しました。」のメッセージが出るように下記を追記
``` 
　　　  .fail(function (jqXHR, textStatus, errorThrown) {
     　　　$("#error-message").text("更新に失敗しました。").show().fadeOut(3000);
     　　　console.log("通信に失敗しました。", "ステータスコード：" + jqXHR.status);
   　　　});
```

-  CategoryController.java

　　　・カテゴリーIDに紐付いている商品IDを`List<Long> data`に格納し、データをブラウザへ送れるよう下記を記述
```
	　List<Long> data = new ArrayList<>();
	　for (CategoryProduct categoryProduct : category.get().getCategoryProducts()) {
		Long productId = categoryProduct.getProductId();
		data.add(productId);
	　}
	　model.addAttribute("data", data);
```