### PR TITLE
fix:No.18_ 未使用コード入力時のエラー, No.19_コード未入力時のエラー表示

### DIFF
--- a/src/main/java/com/example/controller/CampaignController.java
+++ b/src/main/java/com/example/controller/CampaignController.java
@@ -75,9 +75,12 @@ public class CampaignController {
 	@GetMapping("/{id}")
 	public String show(Model model, @PathVariable("id") Long id) {
 		if (id != null) {
-			Optional<Category> campaign = categoryService.findOne(id);
-			model.addAttribute("campaign", campaign.get());
-			this.setCommonData(model);
+			Optional<Campaign> campaign = campaignService.findOne(id);
+			if (campaign.isPresent()) {
+				model.addAttribute("campaign", campaign.get());
+				this.setCommonData(model);
+				return "campaign/show";
+			}
 		}
 		return "campaign/show";
 	}
@@ -143,7 +146,7 @@ public class CampaignController {
 			if (!CheckUtil.checkDescriptionLength(campaign.getDescription())) {
 				// NG
 				redirectAttributes.addFlashAttribute("error", Message.MSG_VALIDATE_ERROR);
-				return "redirect:/campaigns";
+				return "redirect:/campaigns/" + campaign.getId() + "/edit";
 			}
 
 			target = campaignService.save(campaign);
@@ -152,7 +155,7 @@ public class CampaignController {
 		} catch (Exception e) {
 			redirectAttributes.addFlashAttribute("error", Message.MSG_ERROR);
 			e.printStackTrace();
-			return "redirect:/campaigns";
+			return "redirect:/campaigns/" + campaign.getId() + "/edit";
 		}
 	}
 

--- a/src/main/java/com/example/validate/UnusedCampaignCodeValidator.java
+++ b/src/main/java/com/example/validate/UnusedCampaignCodeValidator.java
@@ -49,6 +49,14 @@ public class UnusedCampaignCodeValidator implements ConstraintValidator<UnusedCa
 		Long id = (Long)beanWrapper.getPropertyValue(fields[0]);
 		String code = (String)beanWrapper.getPropertyValue(fields[1]);
 
+		// 画面で入力したキャンペーンコードが空文字列の場合はエラーを返す
+		if (code == null || code.isEmpty()) {
+			context.disableDefaultConstraintViolation();
+			context.buildConstraintViolationWithTemplate("キャンペーンコードを入力してください。").addPropertyNode(fields[1])
+					.addConstraintViolation();
+			return false;
+		}
+
 		// 画面で入力したキャンペーンコードを元にDBからキャンペーンを取得
 		Campaign campaign = service.findByCode(code).orElse(null);
 
@@ -58,9 +66,8 @@ public class UnusedCampaignCodeValidator implements ConstraintValidator<UnusedCa
 			return true;
 		}
 		context.disableDefaultConstraintViolation();
-		context.buildConstraintViolationWithTemplate(message).addPropertyNode(fields[1])
+		context.buildConstraintViolationWithTemplate("すでに登録済みのキャンペーンコードです。").addPropertyNode(fields[1])
 				.addConstraintViolation();
-
 		return false;
 	}
 }


### PR DESCRIPTION
**概要**
　No.18：編集時に「すでに登録済みのキャンペーンコードです。」と表示されて更新できない不具合を修正

　No.19：Code（キャンペーンコード）が空のまま登録できるため、エラーメッセージが表示されるように修正

**修正方針**
　No.18：未使用のコード入力時にエラーメッセージが出ないように修正

　No.19：エラー内容によってエラーメッセージの文言を出し分ける

**変更点**
　No.18：

- CampaignController

　　・Controllerの詳細画面がエラーで表示できなかったため、記述を修正してエラー解消

　No.19：

- UnusedCampaignCodeValidator

　　・画面で入力したキャンペーンコードが空文字列の場合はエラーを返す処理を記述
　　・エラー内容によってエラーメッセージの文言を出し分けする記述を追加