### PR TITLE
fix:No.22_画面デザインの修正

### DIFF
--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -14,9 +14,14 @@
 }
 
 /* 詳細 */
-span.font-impact {
-  font-family: "Impact";
-  font-size: small;
+h1 {
+  font-family: "Roboto";
+  font-weight: 700;
+}
+
+span.apps-font {
+  font-family: "Noto Sans JP";
+  font-size: 1rem;
 }
 
 a.btn {
@@ -44,12 +49,10 @@ a.btn-link {
   .for-tablet {
     display: none;
   }
+    /* 詳細 */
   .app-show-container {
-    width: 1500px;
-    height: 3000px;
-  }
-  span.font-impact {
-    font-size: x-large;
+    width: 100%;
+    word-wrap: break-word;
   }
 }
 
@@ -60,10 +63,9 @@ a.btn-link {
     display: none;
   }
 
+  /* 詳細 */
   .app-show-container {
-    width: 1500px;
-  }
-  span.font-impact {
-    font-size: xx-large;
+    width: 100%;
+    word-wrap: break-word;
   }
 }

--- a/src/main/resources/templates/app/show.html
+++ b/src/main/resources/templates/app/show.html
@@ -5,57 +5,61 @@
   layout:decorate="~{layout/layout}"
 >
   <th:block layout:fragment="content">
-    <div class='app-show-container'>
-    <h1>Show App</h1>
-    <hr />
-    <div class="form-group">
-      <label for="name">Name: </label>
-      <span class='font-impact' th:text="${app.name}"></span>
-    </div>
-    <div class="form-group">
-      <label for="email">Url: </label>
-      <span class='font-impact' th:text="${app.url}"></span>
-    </div>
-    <div class="form-group">
-      <label for="description">Description: </label>
-      <span class='font-impact' th:text="${app.description}"></span>
-    </div>
-    <div class="form-group">
-      <label for="image">Image: </label>
-      <!-- 画像があれば表示 -->
-      <img
-        th:if="${app.image != null && app.image != ''}"
-        th:src="${app.image}"
-        th:alt="現在の画像"
-        style="max-width: 200px; max-height: 200px"
-        class="img-filter"
-      />
-    </div>
-    <div class="form-group">
-      <label for="developer">Developer: </label>
-      <span th:text="${app.developer}"></span>
-    </div>
-    <div class="form-group">
-      <label for="active">Active: </label>
-      <span th:text="${app.active}"></span>
-    </div>
-    <div class="form-group">
-      <a class="btn btn-warning" th:href="@{/apps/{id}/edit(id = ${app.id})}"
-      >Edit this record</a
-      >
-      <form
-        class="d-inline"
-        th:action="@{/apps/{id}(id = ${app.id})}"
-        th:method="delete"
-      >
-        <button class="btn btn-info" type="submit">Delete this record</button>
-      </form>
-    </div>
-    <br />
-    <div class="form-group ">
-      <a class="btn btn-light text-right" th:href="@{/apps}">Back to list All apps</a>
-    </div>
-    <br />
+    <div class="app-show-container">
+      <h1>Show App</h1>
+      <hr />
+      <div class="form-group">
+        <label for="name">Name: </label>
+        <span class="apps-font" th:text="${app.name}"></span>
+      </div>
+      <div class="form-group">
+        <label for="email">Url: </label>
+        <span class="apps-font" th:text="${app.url}"></span>
+      </div>
+      <div class="form-group">
+        <label for="description">Description: </label>
+        <span class="apps-font" th:text="${app.description}"></span>
+      </div>
+      <div class="form-group">
+        <label for="image">Image: </label>
+        <!-- 画像があれば表示 -->
+        <img
+          th:if="${app.image != null && app.image != ''}"
+          th:src="${app.image}"
+          th:alt="現在の画像"
+          style="max-width: 200px; max-height: 200px"
+          class="img-filter"
+        />
+      </div>
+      <div class="form-group">
+        <label for="developer">Developer: </label>
+        <span th:text="${app.developer}"></span>
+      </div>
+      <div class="form-group">
+        <label for="active">Active: </label>
+        <span th:text="${app.active}"></span>
+      </div>
+      <div class="form-group">
+        <a class="btn btn-primary" th:href="@{/apps/{id}/edit(id = ${app.id})}"
+          >Edit this record</a
+        >
+        <form
+          class="d-inline"
+          th:action="@{/apps/{id}(id = ${app.id})}"
+          th:method="delete"
+        >
+          <button class="btn btn-danger" type="submit">
+            Delete this record
+          </button>
+        </form>
+      </div>
+      <br />
+      <div class="form-group">
+        <a class="btn btn-secondary" th:href="@{/apps}"
+          >Back to list All apps</a
+        >
+      </div>
+      <br />
     </div>
     <link th:href="@{/css/app.css}" type="text/css" rel="stylesheet" />
   </th:block>


### PR DESCRIPTION
**概要**
　・ボタン配色/フォント/文字サイズが画面設計書と異なるため修正

**修正方針**
　・各種ボタンのクラス名を変更し、画面設計書に沿う色へ変更
　・画面幅を狭めた時のフォントサイズを変更(タブレット/スマホ)
　・画面幅を狭めた時にテキストが画面からはみ出してしまうため、テキストが全文表示されるように処理を追記
　・CSSで当ててあるフォント（Impact）を変更

**変更点**

- app.css
　　・本文とタイトル(h1タグ)にあたっているフォントと文字サイズを変更
```
　　　h1 {
　　　  font-family: "Roboto";
　　　  font-weight: 700;
　　　}

　　　span.apps-font {
 　　　 font-family: "Noto Sans JP";
 　　　 font-size: 1rem;
　　　}
```

　　・タブレット端末や携帯端末でアクセスするとデザインが崩れるため、下記内容で修正
```
・タブレット/携帯で個別にフォントが指定されていたため、削除
・タブレット/携帯でそれぞれ下記を追記し、テキストが画面幅に合わせて折り返されるように記述
　　　 .app-show-container {
　　　    width: 100%;
　　　    word-wrap: break-word;
　　　  }
```

- show.html
・本文にあたっているクラスを右記に変更　`class='font-Impact' → class="apps-font"`

　　・ボタンにあたっているクラスを下記内容で変更
```
　　　class="btn btn-warning"  ⇒  class="btn btn-primary"
　　　class="btn btn-info"  ⇒  class="btn btn-danger"
　　　class="btn btn-light text-right"  ⇒  class="btn btn-secondary"
```