### PR TITLE
fix:No.28_税額の種類をプログラム上に定数で保持をしているものをデータベース化する

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "[java]": {
     "editor.insertSpaces": false
   },
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "java.debug.settings.onBuildFailureProceed": true
 }

--- a/docs/tax.md
+++ b/docs/tax.md
@@ -1,0 +1,54 @@
+# Taxes 設計
+
+## 概要
+
+税額の種類を DB 化する
+
+### アクション
+
+- 参照
+- 登録
+- 編集
+- 削除
+
+### 要件
+
+- 削除する際はその ID を他で使用している場合は削除できない様にしてください。
+
+## モデル
+
+- Tax
+
+| `taxes`      | Type    | memo 　 　　    |
+| ------------ | ------- | --------------- |
+| id           | Integer | 　 　　         |
+| rate         | Integer | 　 　　         |
+| tax_included | TinyInt | 0:税抜　 1:税込 |
+| rounding     | String  | 　 　　         |
+
+## 定数
+
+TODO: データベース化
+
+- TaxType
+
+| ID  | Rate(%) | Tax included | Rounding |
+| --- | ------- | ------------ | -------- |
+| 1   | 0       | No           | Floor    |
+| 2   | 0       | No           | Round    |
+| 3   | 0       | No           | Ceil     |
+| 4   | 0       | Yes          | Floor    |
+| 5   | 0       | Yes          | Round    |
+| 6   | 0       | Yes          | Ceil     |
+| 7   | 8       | No           | Floor    |
+| 8   | 8       | No           | Round    |
+| 9   | 8       | No           | Ceil     |
+| 10  | 8       | Yes          | Floor    |
+| 11  | 8       | Yes          | Round    |
+| 12  | 8       | Yes          | Ceil     |
+| 13  | 10      | No           | Floor    |
+| 14  | 10      | No           | Round    |
+| 15  | 10      | No           | Ceil     |
+| 16  | 10      | Yes          | Floor    |
+| 17  | 10      | Yes          | Round    |
+| 18  | 10      | Yes          | Ceil     |

--- a/src/main/java/com/example/controller/ShopProductController.java
+++ b/src/main/java/com/example/controller/ShopProductController.java
@@ -1,6 +1,5 @@
 package com.example.controller;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,14 +19,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.constants.Message;
-import com.example.constants.TaxType;
 import com.example.entity.ProductWithCategoryName;
 import com.example.form.ProductForm;
 import com.example.form.ProductSearchForm;
 import com.example.model.Category;
 import com.example.model.Product;
+import com.example.model.Tax;
 import com.example.service.CategoryService;
 import com.example.service.ProductService;
+import com.example.service.TaxlistService;
 
 @Controller
 @RequestMapping("/shops/{shopId}/products")
@@ -38,6 +38,9 @@ public class ShopProductController {
 
 	@Autowired
 	private CategoryService categoryService;
+
+	@Autowired
+	private TaxlistService taxlistService;
 
 	@GetMapping
 	public String index(Model model, @PathVariable("shopId") Long shopId, @ModelAttribute ProductSearchForm request) {
@@ -56,10 +59,11 @@ public class ShopProductController {
 		if (id != null) {
 			Optional<Product> product = productService.findOne(id);
 			List<Category> categories = categoryService.findAll();
+			Tax tax = taxlistService.findOne(product.get().getTaxType()).get();
 			model.addAttribute("categories", categories);
 			model.addAttribute("product", product.get());
-			model.addAttribute("tax", TaxType.get(product.get().getTaxType()));
 			model.addAttribute("shopId", shopId);
+			model.addAttribute("tax", tax);
 		}
 		return "shop_product/show";
 	}
@@ -153,5 +157,21 @@ public class ShopProductController {
 			throw new ServiceException(e.getMessage());
 		}
 		return "redirect:/shops/{shopId}/products";
+	}
+
+	/**
+	 * 商品に税率が使用されているか確認
+	 *
+	 * @param id
+	 * @return
+	 */
+	public boolean isExistTax(Integer id) {
+		List<Product> products = productService.findAll();
+		for (Product product : products) {
+			if (product.getTaxType().equals(id)) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/main/java/com/example/controller/TaxListController.java
+++ b/src/main/java/com/example/controller/TaxListController.java
@@ -1,0 +1,151 @@
+package com.example.controller;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.example.constants.Message;
+import com.example.model.Tax;
+
+import org.hibernate.service.spi.ServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.example.service.TaxlistService;
+
+@Controller
+@RequestMapping("/taxlist")
+public class TaxListController {
+
+	@Autowired
+	private TaxlistService taxlistService;
+
+	@Autowired
+	private ShopProductController shopProductController;
+
+	/**
+	 * 一覧画面表示
+	 *
+	 * @param model
+	 * @param form
+	 * @return
+	 */
+	@GetMapping
+	public String index(Model model) {
+		// 全件取得
+		List<Tax> taxlist = taxlistService.findAll();
+
+		model.addAttribute("taxlist", taxlist);
+
+		return "taxlist/index";
+	}
+
+	/**
+	 * 詳細画面表示
+	 *
+	 * @param model
+	 * @param id
+	 * @return
+	 */
+	@GetMapping("/show/{id}")
+	public String show(Model model, @PathVariable("id") Integer id) {
+		if (id != null) {
+			Optional<Tax> taxlist = taxlistService.findOne(id);
+			model.addAttribute("taxlist", taxlist.get());
+		}
+		return "taxlist/show";
+	}
+
+	/**
+	 * 登録画面表示
+	 *
+	 * @param model
+	 * @param id
+	 * @return
+	 */
+	@GetMapping(value = "/create")
+	public String create(Model model, @ModelAttribute Tax entity) {
+		model.addAttribute("taxlist", entity);
+		return "taxlist/form";
+	}
+
+	// 新規登録
+	@PostMapping
+	public String create(Model model, @Validated @ModelAttribute Tax entity, BindingResult result,
+			RedirectAttributes redirectAttributes) {
+		Tax taxlist = new Tax();
+		try {
+			taxlist = taxlistService.save(entity);
+			redirectAttributes.addFlashAttribute("success", Message.MSG_SUCESS_INSERT);
+			return "redirect:/taxlist/show/" + taxlist.getId();
+		} catch (Exception e) {
+			redirectAttributes.addFlashAttribute("error", Message.MSG_ERROR);
+			e.printStackTrace();
+			return "redirect:/taxlist";
+		}
+	}
+
+	/**
+	 * 編集画面表示
+	 *
+	 * @param model
+	 * @param id
+	 * @return
+	 */
+	@GetMapping("/edit/{id}")
+	public String edit(Model model, @PathVariable("id") Integer id) {
+		if (id != null) {
+			Optional<Tax> taxlist = taxlistService.findOne(id);
+			model.addAttribute("taxlist", taxlist.get());
+		}
+		return "taxlist/form";
+	}
+
+	// 更新
+	@PutMapping
+	public String update(Model model, @Validated @ModelAttribute Tax entity, BindingResult result,
+			RedirectAttributes redirectAttributes) {
+		Tax taxlist = null;
+		try {
+			taxlist = taxlistService.save(entity);
+			redirectAttributes.addFlashAttribute("success", Message.MSG_SUCESS_UPDATE);
+			return "redirect:/taxlist/show/" + taxlist.getId();
+		} catch (Exception e) {
+			redirectAttributes.addFlashAttribute("error", Message.MSG_ERROR);
+			e.printStackTrace();
+			return "redirect:/taxlist";
+		}
+	}
+
+	// 削除
+	@DeleteMapping("/{id}")
+	public String delete(@PathVariable("id") Tax id, RedirectAttributes redirectAttributes) {
+		try {
+			if (id != null) {
+				Optional<Tax> taxlist = taxlistService.findOne(id.getId());
+				// Productに存在するか確認
+				if (!shopProductController.isExistTax(taxlist.get().getId())) {
+					taxlistService.delete(taxlist.get());
+					redirectAttributes.addFlashAttribute("success", Message.MSG_SUCESS_DELETE);
+				} else {
+					redirectAttributes.addFlashAttribute("error", "この税率は商品に使用されているため削除できません。");
+				}
+			}
+		} catch (Exception e) {
+			redirectAttributes.addFlashAttribute("error", Message.MSG_ERROR);
+			throw new ServiceException(e.getMessage());
+		}
+		return "redirect:/taxlist";
+	}
+
+}

--- a/src/main/java/com/example/model/OrderProduct.java
+++ b/src/main/java/com/example/model/OrderProduct.java
@@ -3,8 +3,6 @@ package com.example.model;
 import java.io.Serializable;
 import java.lang.String;
 
-import com.example.constants.TaxType;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -53,9 +51,9 @@ public class OrderProduct extends TimeEntity implements Serializable {
 	@Column(name = "tax_rounding", nullable = false)
 	private String taxRounding;
 
-	public void setTaxType(TaxType.Tax tax) {
+	public void setTaxType(Tax tax) {
 		this.setTaxRate(tax.rate);
-		this.setTaxIncluded(tax.taxIncluded);
+		this.setTaxIncluded(tax.tax_included);
 		this.setTaxRounding(tax.rounding);
 	}
 }

--- a/src/main/java/com/example/model/Tax.java
+++ b/src/main/java/com/example/model/Tax.java
@@ -1,0 +1,54 @@
+package com.example.model;
+
+import java.io.Serializable;
+import java.lang.String;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "taxes")
+@Getter
+@Setter
+public class Tax implements Serializable {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	public Integer id;
+
+	@Column(name = "rate", nullable = true)
+	public Integer rate;
+
+	@Column(name = "tax_included", nullable = true)
+	public Boolean tax_included;
+
+	@Column(name = "rounding", nullable = true)
+	public String rounding;
+
+	public static Tax get(Integer id) {
+		List<Tax> taxes = new ArrayList<Tax>();
+		for (Tax tax : taxes) {
+			if (tax.id.equals(id)) {
+				return tax;
+			}
+		}
+		return null;
+	}
+
+	public static Tax get(Integer rate, Boolean tax_included, String rounding) {
+		List<Tax> taxes = new ArrayList<Tax>();
+		for (Tax tax : taxes) {
+			if (tax.rate.equals(rate) && tax.tax_included.equals(tax_included) && tax.rounding.equals(rounding)) {
+				return tax;
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/example/repository/TaxListRepository.java
+++ b/src/main/java/com/example/repository/TaxListRepository.java
@@ -1,0 +1,16 @@
+package com.example.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.model.Tax;
+
+@Repository
+public interface TaxListRepository extends JpaRepository<Tax, Integer> {
+
+	// save()
+	Tax save(Tax entity);
+
+	// delete()
+	void delete(Tax entity);
+}

--- a/src/main/java/com/example/service/OrderService.java
+++ b/src/main/java/com/example/service/OrderService.java
@@ -3,13 +3,13 @@ package com.example.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.example.constants.TaxType;
 import com.example.enums.OrderStatus;
 import com.example.enums.PaymentStatus;
 import com.example.form.OrderForm;
 import com.example.model.Order;
 import com.example.model.OrderPayment;
 import com.example.model.OrderProduct;
+import com.example.model.Tax;
 import com.example.repository.OrderRepository;
 import com.example.repository.ProductRepository;
 
@@ -62,7 +62,7 @@ public class OrderService {
 			orderProduct.setQuantity(p.getQuantity());
 			orderProduct.setPrice((double)product.getPrice());
 			orderProduct.setDiscount(p.getDiscount());
-			orderProduct.setTaxType(TaxType.get(product.getTaxType()));
+			orderProduct.setTaxRate(Tax.get(product.getTaxType()).getRate());
 			orderProducts.add(orderProduct);
 		});
 
@@ -87,9 +87,9 @@ public class OrderService {
 			}
 			// 端数処理
 			tax = switch (orderProduct.getTaxRounding()) {
-			case TaxType.ROUND -> Math.round(tax);
-			case TaxType.CEIL -> Math.ceil(tax);
-			case TaxType.FLOOR -> Math.floor(tax);
+			case "round" -> Math.round(tax);
+			case "floor" -> Math.floor(tax);
+			case "ceil" -> Math.ceil(tax);
 			default -> tax;
 			};
 			var subTotal = price * quantity + tax - discount;

--- a/src/main/java/com/example/service/TaxlistService.java
+++ b/src/main/java/com/example/service/TaxlistService.java
@@ -1,0 +1,33 @@
+package com.example.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.model.Tax;
+import com.example.repository.TaxListRepository;
+
+@Service
+public class TaxlistService {
+
+	@Autowired
+	private TaxListRepository taxlistRepository;
+
+	public List<Tax> findAll() {
+		return taxlistRepository.findAll();
+	}
+
+	public Optional<Tax> findOne(Integer id) {
+		return taxlistRepository.findById(id);
+	}
+
+	public Tax save(Tax entity) {
+		return taxlistRepository.save(entity);
+	}
+
+	public void delete(Tax entity) {
+		taxlistRepository.delete(entity);
+	}
+}

--- a/src/main/resources/templates/shop_product/show.html
+++ b/src/main/resources/templates/shop_product/show.html
@@ -45,15 +45,15 @@
       <span th:if="${tax.rate == 0}">非課税（0%）</span>
     </div>
     <div class="form-group">
-      <label for="taxIncluded">入力価格: </label>
-      <span th:if="${tax.taxIncluded == true}">税込価格</span>
-      <span th:if="${tax.taxIncluded == false}">税抜き価格</span>
+      <label for="tax_included">入力価格: </label>
+      <span th:if="${tax.tax_included == true}">税込価格</span>
+      <span th:if="${tax.tax_included == false}">税抜き価格</span>
     </div>
     <div class="form-group">
       <label for="rounding">端数処理: </label>
-      <span th:if="${tax.rounding == 'floor'}">切り捨て</span>
-      <span th:if="${tax.rounding == 'round'}">四捨五入</span>
-      <span th:if="${tax.rounding == 'ceil'}">切り上げ</span>
+      <span th:if="${tax.rounding == 'Floor'}">切り捨て</span>
+      <span th:if="${tax.rounding == 'Round'}">四捨五入</span>
+      <span th:if="${tax.rounding == 'Ceil'}">切り上げ</span>
     </div>
 
     <a

--- a/src/main/resources/templates/taxlist/form.html
+++ b/src/main/resources/templates/taxlist/form.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html
+  xmlns:th="http://www.thymeleaf.org"
+  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+  layout:decorate="~{layout/layout}"
+>
+  <th:block layout:fragment="content">
+    <h1 th:if="${taxlist.id == null}">税率新規作成</h1>
+    <h1 th:if="${taxlist.id != null}">税率編集</h1>
+    <hr />
+    <form
+      th:action="@{/taxlist}"
+      th:method="@{${taxlist.id == null} ? 'post' : 'put'}"
+      th:object="${taxlist}"
+    >
+      <input type="hidden" th:field="*{id}" />
+
+      <div class="form-group">
+        <label for="rate">税率</label>
+        <input type="number" id="rate" name="rate" class="form-control" th:field="*{rate}" th:errorclass="is-invalid" />
+
+      <div class="form-group">
+        <label for="tax_included">入力価格</label>
+        <select
+          id="tax_included"
+          name="tax_included"
+          class="form-control"
+          th:field="*{tax_included}"
+          th:errorclass="is-invalid"
+        >
+          <option value="0">税抜き価格</option>
+          <option value="1">税込み価格</option>
+        </select>
+        <div class="invalid-feedback" th:errors="*{tax_included}"></div>
+      </div>
+
+      <div class="form-group">
+        <label for="rounding">端数処理</label>
+        <select
+          id="rounding"
+          name="rounding"
+          class="form-control"
+          th:field="*{rounding}"
+          th:errorclass="is-invalid"
+        >
+          <option value="Floor">切り捨て</option>
+          <option value="Ceil">切り上げ</option>
+          <option value="Round">四捨五入</option>
+        </select>
+        <div class="invalid-feedback" th:errors="*{rounding}"></div>
+      </div>
+
+      <button type="submit" class="btn btn-success">保存</button>
+      <a th:href="@{/taxlist}" class="btn btn-default">戻る</a>
+    </form>
+  </th:block>
+</html>

--- a/src/main/resources/templates/taxlist/index.html
+++ b/src/main/resources/templates/taxlist/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html
+  xmlns:th="http://www.thymeleaf.org"
+  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+  layout:decorate="~{layout/layout}"
+>
+  <th:block layout:fragment="content">
+    <h1>税率一覧</h1>
+    <a class="btn btn-link" th:href="@{/taxlist/create}">新規作成</a>
+    <hr />
+    <table class="table">
+      <thead>
+        <tr>
+          <th>税率</th>
+          <th>入力価格</th>
+          <th>端数処理</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr th:each="taxlist : ${taxlist}">
+          <td th:text="${taxlist.rate + '%'}"></td>
+          <td
+            th:text="${taxlist.tax_included ? '税込み価格' : '税抜き価格'}"
+          ></td>
+          <td
+            th:text="${taxlist.rounding == 'Floor' ? '切り捨て' : (taxlist.rounding == 'Ceil' ? '切り上げ' : '四捨五入')}"
+          ></td>
+          <td>
+            <a
+              class="btn btn-primary"
+              th:href="@{/taxlist/show/{id}(id = ${taxlist.id})}"
+              >詳細</a
+            >
+            <a
+              class="btn btn-secondary"
+              th:href="@{/taxlist/edit/{id}(id = ${taxlist.id})}"
+              >編集</a
+            >
+            <form
+              class="d-inline"
+              th:action="@{/taxlist/{id}(id = ${taxlist.id})}"
+              th:method="delete"
+            >
+              <button class="btn btn-danger" type="submit">削除</button>
+            </form>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </th:block>
+</html>

--- a/src/main/resources/templates/taxlist/show.html
+++ b/src/main/resources/templates/taxlist/show.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html
+  xmlns:th="http://www.thymeleaf.org"
+  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+  layout:decorate="~{layout/layout}"
+>
+  <th:block layout:fragment="content">
+    <h1>税額詳細</h1>
+    <hr />
+    <div class="form-group">
+      <label for="rate">税率: </label>
+      <span th:text="${taxlist.rate} + '%'"></span>
+    </div>
+    <div class="form-group">
+      <label for="tax_included">入力価格: </label>
+      <span
+        th:text="${taxlist.tax_included ? '税込み価格' : '税抜き価格'}"
+      ></span>
+    </div>
+    <div class="form-group">
+      <label for="rounding">端数処理: </label>
+      <span
+        th:text="${taxlist.rounding == 'Floor' ? '切り捨て' : (taxlist.rounding == 'Ceil' ? '切り上げ' : '四捨五入')}"
+      ></span>
+    </div>
+
+    <a class="btn btn-link" th:href="@{/taxlist/edit/{id}(id = ${taxlist.id})}"
+      >編集</a
+    >
+    <br />
+    <form th:action="@{/taxlist/{id}(id = ${taxlist.id})}" th:method="delete">
+      <button class="btn btn-link" type="submit">削除</button>
+    </form>
+    <a class="btn btn-link" th:href="@{/taxlist}">一覧へ戻る</a>
+    <br />
+  </th:block>
+</html>


### PR DESCRIPTION
**概要**
税額の種類をプログラム上に定数で保持をしているが、今後の税率変更などに対応するために、あらかじめデータベース化を行いたい。
・定数ファイルをそのままデータベース化し、参照・登録・編集・削除が行える様にページの新規作成。
・削除する際はそのIDを他で使用している場合は削除できない様に修正。

**修正方針**
・TaxTypeを基にドキュメントとDBテーブルの作成
・DBへの移行に伴い、TaxType.javaのメソッド使用有無を確認
・使っている場合：Repository経由で取得できるようにmodel/Repository作成
・Repository作成してDBから全件取得(Controllerでログで確認)
・画面に渡す(Tymeleafで出力)
・ページ作成→機能を実装→残りの所処理
・TaxType.javaを使用していたクラス（OrderService,OrderProduct,ShopProductController)の処理の修正
・使用しているIDは削除できないように処理を追加

**変更点**
・docs/tax.md
　　↳新規作成

・Tax.java
　　↳新規作成

・TaxlistRepository.java
　　↳新規作成

・TaxListController.java
　　↳一覧画面、新規/編集画面、詳細画面が出力できるよう処理を記述
　　↳登録、更新、削除、参照が行えるよう処理を記述

・taxlist/form.html
　　↳新規作成：登録/更新フォームの作成

・taxlist/index.html
　　↳新規作成：一覧画面の作成

・taxlist/show.html
　　↳新規作成：詳細画面の作成

・OrderProduct.java
　　↳TaxType.javaのメソッドを使用していたため、新規作成したEntity(Tax.java)からデータの取得できるよう修正

・OrderService.java
　　↳TaxType.javaのメソッドを使用していたため、新規作成したEntity(Tax.java)からデータの取得できるよう修正

・ShopProductController.java
　　↳TaxType.javaのメソッドを使用していたため、新規作成したEntity(Tax.java)からデータの取得・画面表示ができるよう修正
　　↳削除の条件分岐用に`isExistTax()`を実施

・shop_product/show.html
　　↳詳細画面の表示に関わるTymeleafの記述を修正